### PR TITLE
fix: bump max request body size for ExpressJS json parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -36,12 +36,12 @@ workflows:
 
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - hokusai/test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: peril
           requires:
             - push-staging-image

--- a/api/source/peril.ts
+++ b/api/source/peril.ts
@@ -42,7 +42,7 @@ export const peril = () => {
   const app = express()
   app.set("port", process.env.PORT || 5000)
   app.use(xhub({ algorith: "sha1", secret: PERIL_WEBHOOK_SECRET }))
-  app.use(bodyParser.json())
+  app.use(bodyParser.json({ limit: "5mb" }))
   app.use(express.static("public"))
 
   app.post("/webhook", githubRouter)


### PR DESCRIPTION
It looks like the default maximum request body size for the ExpressJS body parser is [100kb](https://github.com/expressjs/body-parser#limit). It looks like GitHub is sending payloads larger than this limit so we occasionally see some behavior skipped without any notice.

cc/ @MounirDhahri 

**Logs**

```
info: ## status.success on artsy on artsy/force
info:    1 run needed: artsy/peril-settings@org/mergeOnGreen.ts
PayloadTooLargeError: request entity too large
    at readStream (/app/node_modules/express-x-hub/node_modules/raw-body/index.js:155:17)
    at getRawBody (/app/node_modules/express-x-hub/node_modules/raw-body/index.js:108:12)
    at /app/node_modules/express-x-hub/lib/middleware.js:43:9
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:317:13)
    at /app/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/app/node_modules/express/lib/router/index.js:335:12)
    at next (/app/node_modules/express/lib/router/index.js:275:10)
    at expressInit (/app/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:317:13)
    at /app/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/app/node_modules/express/lib/router/index.js:335:12)
    at next (/app/node_modules/express/lib/router/index.js:275:10)
    at query (/app/node_modules/express/lib/middleware/query.js:45:5)
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
```